### PR TITLE
Add an Assertion to test Closure code

### DIFF
--- a/tests/TravelTest.php
+++ b/tests/TravelTest.php
@@ -8,6 +8,13 @@ use RachidLaasri\Travel\Travel;
 
 class TravelTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Travel::back();
+    }
+
     /** @test */
     public function it_can_travel_to_a_datetime()
     {

--- a/tests/TravelTest.php
+++ b/tests/TravelTest.php
@@ -35,8 +35,13 @@ class TravelTest extends TestCase
         $this->assertEquals('22-04-1994', Carbon::now()->format('d-m-Y'));
 
         Travel::to('22-04-1995', function () {
-            // Do something!
+            $this->assertEquals(
+                '22-04-1995',
+                Carbon::now()->format('d-m-Y'),
+                'Code inside the Closure should match the travel time.'
+            );
         });
+
         $this->assertNotEquals('22-04-1995', Carbon::now()->format('d-m-Y'));
     }
 

--- a/tests/TravelTest.php
+++ b/tests/TravelTest.php
@@ -33,15 +33,19 @@ class TravelTest extends TestCase
     {
         Travel::to('22-04-1994');
         $this->assertEquals('22-04-1994', Carbon::now()->format('d-m-Y'));
+        $calledCount = 0;
 
-        Travel::to('22-04-1995', function () {
+        Travel::to('22-04-1995', function () use (&$calledCount) {
             $this->assertEquals(
                 '22-04-1995',
                 Carbon::now()->format('d-m-Y'),
                 'Code inside the Closure should match the travel time.'
             );
+
+            $calledCount++;
         });
 
+        $this->assertEquals(1, $calledCount, 'Expect the closure to be called once.');
         $this->assertNotEquals('22-04-1995', Carbon::now()->format('d-m-Y'));
     }
 

--- a/tests/TravelTest.php
+++ b/tests/TravelTest.php
@@ -33,6 +33,7 @@ class TravelTest extends TestCase
     {
         Travel::to('22-04-1994');
         $this->assertEquals('22-04-1994', Carbon::now()->format('d-m-Y'));
+
         $calledCount = 0;
 
         Travel::to('22-04-1995', function () use (&$calledCount) {


### PR DESCRIPTION
Nice idea!

I am writing an article about this lib for Laravel News, and thought I would send a quick proposed update to the tests:

1. Add an assertion for time inside of closure code.
2. Ensure each test resets Carbon for a fresh slate each time.
3. The test now asserts that the closure is called