### PR TITLE
Add each method to Travel

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ Travel::to('-5 minutes', function() {
 });
 
 ```
+
+Travel to multiple dates with:
+
+```php
+// Travel to random dates, talk with people from the past and come back.
+Travel::each(['01-01-2009', '04-02-2009', '03-02-2006'], function() {
+    // Do something.
+});
+```
+
  Reset the date to today's date
 ```php
 Travel::back();

--- a/src/Travel.php
+++ b/src/Travel.php
@@ -28,6 +28,24 @@ class Travel
     }
 
     /**
+     * Travel to each date given.
+     *
+     * @param mixed $dates
+     * @param Closure $callback
+     * @return void
+     */
+    public static function each($dates, Closure $callback): void
+    {
+        foreach ($dates as $date) {
+            Carbon::setTestNow($date);
+
+            $callback();
+        }
+
+        self::back();
+    }
+
+    /**
      * Travel back to the current date time.
      *
      * @return Carbon

--- a/tests/TravelTest.php
+++ b/tests/TravelTest.php
@@ -3,6 +3,7 @@
 namespace RachidLaasri\Travel\Tests;
 
 use Carbon\Carbon;
+use Carbon\CarbonPeriod;
 use PHPUnit\Framework\TestCase;
 use RachidLaasri\Travel\Travel;
 
@@ -48,6 +49,57 @@ class TravelTest extends TestCase
 
         $this->assertEquals(1, $calledCount, 'Expect the closure to be called once.');
         $this->assertNotEquals('22-04-1995', Carbon::now()->format('d-m-Y'));
+    }
+
+    /** @test */
+    public function it_can_loop_over_each_date_in_an_array()
+    {
+        $dates = ['22-04-1994', '22-04-1995', '29-11-2000'];
+
+        $calledForDates = [];
+        $calledCount = 0;
+
+        Travel::each($dates, function () use (&$calledForDates, $dates, &$calledCount) {
+            $calledForDates[] = Carbon::now()->format('d-m-Y');
+
+            $this->assertEquals(
+                $dates[$calledCount],
+                Carbon::now()->format('d-m-Y'),
+                'Code inside the Closure should match the travel time.'
+            );
+
+            $calledCount++;
+        });
+
+        $this->assertEquals($dates, $calledForDates);
+        $this->assertNotEquals('29-11-2000', Carbon::now()->format('d-m-Y'));
+    }
+
+    /** @test */
+    public function it_can_loop_over_each_date_in_a_carbon_period()
+    {
+        $period = CarbonPeriod::create('1994-04-22', '3 days', '1994-04-28');
+        $dates = array_map(function (Carbon $date) {
+            return $date->format('d-m-Y');
+        }, $period->toArray());
+
+        $calledForDates = [];
+        $calledCount = 0;
+
+        Travel::each($period, function () use (&$calledForDates, $dates, &$calledCount) {
+            $calledForDates[] = Carbon::now()->format('d-m-Y');
+
+            $this->assertEquals(
+                $dates[$calledCount],
+                Carbon::now()->format('d-m-Y'),
+                'Code inside the Closure should match the travel time.'
+            );
+
+            $calledCount++;
+        });
+
+        $this->assertEquals($dates, $calledForDates);
+        $this->assertNotEquals('28-04-1994', Carbon::now()->format('d-m-Y'));
     }
 
     /** @test */


### PR DESCRIPTION
Hello,

This PR adds the `each` method to Travel class. It works on any `iterable`, including CarbonPeriod, which could be useful.

Thanks,
Otto